### PR TITLE
Added functionality for adding enemies

### DIFF
--- a/SpyDuh/DataAccess/EnemyTableRepository.cs
+++ b/SpyDuh/DataAccess/EnemyTableRepository.cs
@@ -1,0 +1,40 @@
+﻿using SpyDuh.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace SpyDuh.DataAccess
+{
+    public class EnemyTableRepository
+    {
+        static List<EnemyRelationshipTable> _enemyTable = new List<EnemyRelationshipTable>();
+
+        internal void Add(EnemyRelationshipTable relationshipTable)
+        {
+            _enemyTable.Add(relationshipTable);
+        }
+        internal List<EnemyRelationshipTable> Remove(Guid userId, Guid enemyId)
+        {
+            var enemyToRemove = _enemyTable.FirstOrDefault(table => table.UserId == userId && table.EnemyId == enemyId);
+            _enemyTable.Remove(enemyToRemove);
+            return _enemyTable;
+        }
+        internal IEnumerable<Guid> GetEnemies(Guid userId)
+        {
+            var tables = _enemyTable.Where(tables => tables.UserId == userId).ToList();
+            List<Guid> enemyList = new List<Guid>();
+            tables.ForEach(id => enemyList.Add(id.EnemyId));
+            return enemyList;
+        }
+        internal bool CheckUniqueEnemyTable(Guid userId, Guid enemyId)
+        {
+            var uniqueId = _enemyTable.FirstOrDefault(table => table.EnemyId == enemyId && table.UserId == userId);
+            if (uniqueId != null)
+            {
+                return false;
+            }
+            return true;
+        }
+    }
+}

--- a/SpyDuh/DataAccess/FriendTableRepository.cs
+++ b/SpyDuh/DataAccess/FriendTableRepository.cs
@@ -13,6 +13,12 @@ namespace SpyDuh.DataAccess
         {
             _friendTable.Add(relationshipTable);
         }
+        internal List<FriendRelationshipTable> Remove(Guid userId, Guid friendId)
+        {
+            var friendToRemove = _friendTable.FirstOrDefault(table => table.UserId == userId && table.FriendId == friendId);
+            _friendTable.Remove(friendToRemove);
+            return _friendTable;
+        }
         internal IEnumerable<Guid> GetFriends(Guid userId)
         {
             var tables = _friendTable.Where(table => table.UserId == userId).ToList();
@@ -20,7 +26,7 @@ namespace SpyDuh.DataAccess
             tables.ForEach(id => friendsList.Add(id.FriendId));
             return friendsList;
         }
-        internal bool CheckUniqueTable(Guid userId, Guid friendId)
+        internal bool CheckUniqueFriendTable(Guid userId, Guid friendId)
         {
             var uniqueId = _friendTable.FirstOrDefault(table => table.FriendId == friendId && table.UserId == userId);
             if (uniqueId != null)

--- a/SpyDuh/Models/EnemyRelationshipTable.cs
+++ b/SpyDuh/Models/EnemyRelationshipTable.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace SpyDuh.Models
+{
+    public class EnemyRelationshipTable
+    {
+        public Guid Id { get; set; }
+        public Guid UserId { get; set; }
+        public Guid EnemyId { get; set; }
+    }
+}


### PR DESCRIPTION
Added ability to add enemies to a SpyDuh Member's enemy list via SpyName.

Added checks to see if the relationship being added either exists in the friends table or enemy table.

If the user is adding a friend but the relationship already exists in the friend table, it will throw a BadRequest.
If the user is adding a friend and the relationship does not exist in the friend table but exists in the user's enemy table, it will remove that relationship from the enemy table, add it to friend table and update both.

If the user is adding an enemy but the relationship already exists in the enemy table, it will throw a BadRequest.
If the user is adding an enemy and the relationship does not exist in the enemy table but exists in the user's friend table, it will remove that relationship from the friend table, add it to enemy table and update both.

Friend and enemy relationships should not exist simultaneously unless for example

User A has User B as an enemy but User B has User A as a friend. This should be ok.
